### PR TITLE
new window event: EventVisible

### DIFF
--- a/consts.go
+++ b/consts.go
@@ -291,6 +291,8 @@ const (
 	EventCloseWindow
 	// Make a control (Target field of Event structure) to recalculate and reposition all its children
 	EventLayout
+	// a control has changed its visibility
+	EventVisible
 )
 
 // ConfirmationDialog and SelectDialog exit codes

--- a/window.go
+++ b/window.go
@@ -23,6 +23,7 @@ type Window struct {
 	onClose        func(Event) bool
 	onKeyDown      func(Event) bool
 	onScreenResize func(Event)
+	onVisible      func(Event)
 }
 
 func CreateWindow(x, y, w, h int, title string) *Window {
@@ -273,6 +274,10 @@ func (w *Window) OnScreenResize(fn func(Event)) {
 	w.onScreenResize = fn
 }
 
+func (w *Window) OnVisible(fn func(Event)) {
+	w.onVisible = fn
+}
+
 // SetMaximized opens the view to full screen or restores its
 // previous size
 func (w *Window) SetMaximized(maximize bool) {
@@ -319,6 +324,10 @@ func (w *Window) SetVisible(visible bool) {
 		} else {
 			WindowManager().activateWindow(w)
 		}
+	}
+
+	if visible && w.onVisible != nil {
+		w.onVisible(Event{Type: EventVisible})
 	}
 }
 


### PR DESCRIPTION
Whenever a window has changed its visibility property, we call a user
defined callback in order to notify a window has changed its visibility.

It was initially part of PR #87.