### PR TITLE
base_control: fix set visible event dispatching

### DIFF
--- a/base_control.go
+++ b/base_control.go
@@ -172,7 +172,7 @@ func (c *BaseControl) SetVisible(visible bool) {
 	}
 
 	go func() {
-		if !c.inactive {
+		if FindFirstActiveControl(c) != nil && !c.inactive {
 			PutEvent(Event{Type: EventKey, Key: term.KeyTab})
 		}
 		PutEvent(Event{Type: EventLayout, Target: p})

--- a/ctrlutil.go
+++ b/ctrlutil.go
@@ -178,6 +178,16 @@ func ActiveControl(parent Control) Control {
 	return FindFirstControl(parent, fnActive)
 }
 
+// FindFirstActiveControl returns the first active control of a parent
+func FindFirstActiveControl(parent Control) Control {
+	for _, curr := range getLinearControlList(parent, nil) {
+		if curr.Active() {
+			return curr
+		}
+	}
+	return nil
+}
+
 func getLinearControlList(parent Control, fn func(Control) bool) []Control {
 	result := []Control{}
 


### PR DESCRIPTION
Currently when setting a control visible no matter if this control has
active children new KeyTab events will be dispatched. This results in
errors when an application has explicitly set the active control -
i.e with clui.ActivateControl().

In this case the expected behavior is to have that control active
instead of the next one, since we are not considering the the children
state then we always emit the KeyTab event resulting into a focus/active
status change.

This patch changes this behavior by querying the children's status and
checking if there is a child with active state set and only triggering
the KeyTab event when no child is active.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>