### PR TITLE
ctrlutil: fix NextControl()

### DIFF
--- a/ctrlutil.go
+++ b/ctrlutil.go
@@ -218,6 +218,10 @@ func NextControl(parent Control, curr Control, next bool) Control {
 
 	linear := getLinearControlList(parent, fnTab)
 
+	if len(linear) == 0 {
+		return nil
+	}
+
 	var pIndex, nIndex int
 
 	for i, ch := range linear {


### PR DESCRIPTION
With this helper we may iterate over the control list and end up
not having any control that match the search criteria (namely: tabStop,
visible and enabled). In that case an index out of bounds error will
happen.

This patch checks for the resulting list and return if no control's
found.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>