### PR TITLE
NextControl also considers parent's visibility

### DIFF
--- a/ctrlutil.go
+++ b/ctrlutil.go
@@ -213,7 +213,21 @@ func getLinearControlList(parent Control, fn func(Control) bool) []Control {
 // that has tab-stop feature on. Used by library when processing TAB key
 func NextControl(parent Control, curr Control, next bool) Control {
 	fnTab := func(c Control) bool {
-		return c.TabStop() && c.Visible() && c.Enabled()
+		isVisible := func() bool {
+			ctrl := c.Parent()
+
+			for ctrl != nil {
+				if !ctrl.Visible() {
+					return false
+				}
+
+				ctrl = ctrl.Parent()
+			}
+
+			return c.Visible()
+		}
+
+		return c.TabStop() && isVisible() && c.Enabled()
 	}
 
 	linear := getLinearControlList(parent, fnTab)


### PR DESCRIPTION
Whenever running through NextControl() also exclude those controls
which parents are also non visible.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>