### PR TITLE
Don't consider hidden children on ChildAt

### DIFF
--- a/ctrlutil.go
+++ b/ctrlutil.go
@@ -71,6 +71,10 @@ func ChildAt(parent Control, x, y int) Control {
 	var ctrl Control
 	ctrl = parent
 	for _, child := range parent.Children() {
+		if !child.Visible() {
+			continue
+		}
+
 		check := ChildAt(child, x, y)
 		if check != nil {
 			ctrl = check


### PR DESCRIPTION
When dealing with mouse events we use ChildAt() to find the controls
in the clicked area, but we may have hidden elements in the same position
in that case we want to dispatch events to the visible one. This patch
fixes this issue by filtering out the non visible elements.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>