### PR TITLE
Allow for No Border on Window

### DIFF
--- a/canvas.go
+++ b/canvas.go
@@ -381,8 +381,12 @@ func DrawFrame(x, y, w, h int, border BorderStyle) {
 	var chars string
 	if border == BorderThick {
 		chars = SysObject(ObjDoubleBorder)
-	} else {
+	} else if border == BorderThin {
 		chars = SysObject(ObjSingleBorder)
+	} else if border == BorderNone {
+		chars = "      "
+	} else {
+		chars = "      "
 	}
 
 	parts := []rune(chars)

--- a/composer.go
+++ b/composer.go
@@ -10,8 +10,9 @@ import (
 // one object of this type
 type Composer struct {
 	// list of visible Views
-	windows  []Control
-	consumer Control
+	windows      []Control
+	windowBorder BorderStyle
+	consumer     Control
 	// last pressed key - to make repeatable actions simpler, e.g, at first
 	// one presses Ctrl+S and then just repeatedly presses arrow lest to
 	// resize Window
@@ -34,6 +35,7 @@ var (
 func initComposer() {
 	comp = new(Composer)
 	comp.windows = make([]Control, 0)
+	comp.windowBorder = BorderAuto
 	comp.consumer = nil
 	comp.lastKey = term.KeyEsc
 }
@@ -100,6 +102,7 @@ func RefreshScreen() {
 // title is a Window title
 func AddWindow(posX, posY, width, height int, title string) *Window {
 	window := CreateWindow(posX, posY, width, height, title)
+	window.SetBorder(comp.windowBorder)
 
 	comp.BeginUpdate()
 	comp.windows = append(comp.windows, window)
@@ -112,6 +115,16 @@ func AddWindow(posX, posY, width, height int, title string) *Window {
 	RefreshScreen()
 
 	return window
+}
+
+// Border returns the default window border
+func (c *Composer) BorderStyle() BorderStyle {
+	return c.windowBorder
+}
+
+// SetBorder changes the default window border
+func (c *Composer) SetBorder(border BorderStyle) {
+	c.windowBorder = border
 }
 
 // BeginUpdate locks any screen update until EndUpdate is called.

--- a/consts.go
+++ b/consts.go
@@ -21,7 +21,7 @@ const (
 
 // Predefined types
 type (
-	// BorderStyle is a kind of frame: none, single, and double
+	// BorderStyle is a kind of frame: auto, none, thin, and thick
 	BorderStyle int
 	// ViewButton is a set of buttons displayed in a view title
 	ViewButton int
@@ -90,7 +90,8 @@ type Event struct {
 
 // BorderStyle constants
 const (
-	BorderNone BorderStyle = iota
+	BorderAuto BorderStyle = iota - 1
+	BorderNone
 	BorderThin
 	BorderThick
 )

--- a/frame.go
+++ b/frame.go
@@ -40,6 +40,10 @@ func CreateFrame(parent Control, width, height int, bs BorderStyle, scale int) *
 		height = 3
 	}
 
+	if bs == BorderAuto {
+		bs = BorderNone
+	}
+
 	f.SetSize(width, height)
 	f.SetConstraints(width, height)
 	f.border = bs

--- a/window.go
+++ b/window.go
@@ -19,6 +19,7 @@ type Window struct {
 	hidden     bool
 	immovable  bool
 	fixedSize  bool
+	border     BorderStyle
 
 	onClose        func(Event) bool
 	onScreenResize func(Event)
@@ -51,6 +52,7 @@ func CreateWindow(x, y, w, h int, title string) *Window {
 	wnd.SetPaddings(1, 1)
 	wnd.SetGaps(1, 0)
 	wnd.SetScale(1)
+	wnd.SetBorder(BorderAuto)
 
 	return wnd
 }
@@ -75,10 +77,15 @@ func (wnd *Window) drawFrame() {
 	defer PopAttributes()
 
 	var bs BorderStyle
-	if wnd.inactive {
-		bs = BorderThin
+	if wnd.border == BorderAuto {
+		if wnd.inactive {
+			bs = BorderThin
+		} else {
+			bs = BorderThick
+		}
+	} else if wnd.border == BorderNone {
 	} else {
-		bs = BorderThick
+		bs = wnd.border
 	}
 
 	DrawFrame(wnd.x, wnd.y, wnd.width, wnd.height, bs)
@@ -305,6 +312,16 @@ func (w *Window) OnKeyDown(fn func(Event, interface{}) bool, data interface{}) {
 // OnScreenResize sets the callback that is called when size of terminal changes
 func (w *Window) OnScreenResize(fn func(Event)) {
 	w.onScreenResize = fn
+}
+
+// Border returns the default window border
+func (w *Window) Border() BorderStyle {
+	return w.border
+}
+
+// SetBorder changes the default window border
+func (w *Window) SetBorder(border BorderStyle) {
+	w.border = border
 }
 
 // SetMaximized opens the view to full screen or restores its


### PR DESCRIPTION
Keeps current API as-is by defaulting to the new BorderAuto BorderStyle
which keeps the default borders on Windows and defaults on none on Frames.

Allows setting a Window Border to BorderNone for a frameless Window.

Signed-off-by: Mark D Horn <mark.d.horn@intel.com>