### PR TITLE
clui: fix Clipper() function

### DIFF
--- a/base_control.go
+++ b/base_control.go
@@ -546,7 +546,7 @@ func (c *BaseControl) Clipper() (int, int, int, int) {
 		return c.clipper.x, c.clipper.y, c.clipper.w, c.clipper.h
 	}
 
-	return CalcClipper(clipped)
+	return CalcClipper(c)
 }
 
 func (c *BaseControl) setClipper() {


### PR DESCRIPTION
We're using the wrong control to calculate the clipped area, it should
be the clipped control not its clipped parent.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>