### PR TITLE
window: fix event processing

### DIFF
--- a/window.go
+++ b/window.go
@@ -251,7 +251,7 @@ func (c *Window) ProcessEvent(ev Event) bool {
 
 			if aC != nil && aC.Clipped() {
 				clipped = aC
-			} else {
+			} else if nC != nil {
 				clipped = ClippedParent(nC)
 			}
 


### PR DESCRIPTION
Avoid invalid memory address access by no trying to get parent's
control if next control is nil on event processing.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>